### PR TITLE
Enhance VertexPredictor with point feature conditioning

### DIFF
--- a/models/PointCloudToWireframe.py
+++ b/models/PointCloudToWireframe.py
@@ -62,7 +62,7 @@ class PointCloudToWireframe(nn.Module):
         global_features, point_features = self.encoder(point_cloud)
         
         # Predict vertices with existence probabilities
-        vertex_output = self.vertex_predictor(global_features, target_vertex_counts)
+        vertex_output = self.vertex_predictor(global_features, point_features, target_vertex_counts)
         predicted_vertices = vertex_output['vertices']  # (batch_size, max_vertices, 3)
         existence_probabilities = vertex_output['existence_probabilities']  # (batch_size, max_vertices)
         actual_vertex_counts = vertex_output['actual_vertex_counts']  # (batch_size,)

--- a/models/VertexPredictor.py
+++ b/models/VertexPredictor.py
@@ -60,50 +60,74 @@ class VertexPredictor(nn.Module):
         self.residual_proj1 = nn.Linear(global_feature_dim, 2048)  # First residual projection
         self.residual_proj2 = nn.Linear(global_feature_dim, 1024)  # Second residual projection
         
-    def forward(self, global_features, target_vertex_counts=None):
+    def forward(self, global_features, point_features, target_vertex_counts=None):
         """
-        Forward pass for vertex prediction
-        
+        Forward pass for vertex prediction, now using point_features to condition global features.
+
         Args:
             global_features (torch.Tensor): Global features from point cloud encoder (batch_size, global_feature_dim)
+            point_features (torch.Tensor): Per-point features (batch_size, num_points, point_feature_dim)
             target_vertex_counts (torch.Tensor, optional): Ground truth vertex counts for dynamic prediction
-            
+
         Returns:
-            dict: Dictionary containing:
-                - vertices: Predicted vertex coordinates (batch_size, max_vertices, 3)
-                - existence_probabilities: Vertex existence probabilities (batch_size, max_vertices)
-                - actual_vertex_counts: Dynamic vertex counts based on existence probabilities
+            dict: {
+            'vertices': (batch_size, max_vertices, 3),
+            'existence_probabilities': (batch_size, max_vertices),
+            'actual_vertex_counts': (batch_size,)
+            }
         """
         batch_size = global_features.shape[0]
-        
+
+        # If point features are provided, pool them (mean + max) and project to global_feature_dim,
+        # then fuse with global_features (residual addition). The projection layer is created lazily
+        # so its parameters are registered on first forward.
+        if point_features is not None:
+            # point_features: (B, N, C)
+            pooled_mean = point_features.mean(dim=1)                    # (B, C)
+            pooled_max = point_features.max(dim=1).values               # (B, C)
+            pooled = torch.cat([pooled_mean, pooled_max], dim=1)        # (B, 2C)
+
+            # Determine target global dim from an existing layer (registered in __init__)
+            global_dim = self.residual_proj1.in_features
+
+            # Lazily create projection from pooled point-features -> global_dim
+            if not hasattr(self, "point_pool_proj"):
+                self.point_pool_proj = nn.Linear(pooled.shape[1], global_dim)
+                # Move the new layer to the same device as the input tensor
+                self.point_pool_proj = self.point_pool_proj.to(pooled.device)
+
+            point_global = self.point_pool_proj(pooled)                 # (B, global_dim)
+            enhanced_global = global_features + point_global            # Fuse via residual addition
+        else:
+            enhanced_global = global_features
+
         # Deep MLP processing for coordinate prediction with residual connections
-        x = self.vertex_mlp1(global_features)    # First MLP layer
+        x = self.vertex_mlp1(enhanced_global)    # First MLP layer
         x = self.vertex_mlp2(x)                  # Second MLP layer
-        
-        # First residual connection
-        residual1 = self.residual_proj1(global_features)
+
+        # First residual connection (project enhanced global into MLP space)
+        residual1 = self.residual_proj1(enhanced_global)
         x = self.vertex_mlp3(x) + residual1      # Add residual and continue processing
-        
+
         # Second residual connection
-        residual2 = self.residual_proj2(global_features)
+        residual2 = self.residual_proj2(enhanced_global)
         x = self.vertex_mlp4(x) + residual2      # Add second residual
-        
+
         # Generate final vertex features (coordinates + existence probability)
         vertex_features = self.final_layer(x)      # (batch_size, max_vertices * vertex_dim)
-        vertex_features = vertex_features.view(batch_size, self.max_vertices, self.vertex_dim)  # Reshape to vertex features
-        
+        vertex_features = vertex_features.view(batch_size, self.max_vertices, self.vertex_dim)
+
         # Split into coordinates and existence probabilities
-        vertex_coords = vertex_features[:, :, :3]  # First 3 dimensions are coordinates (x, y, z)
-        existence_logits = vertex_features[:, :, 3]  # 4th dimension is existence logit
-        existence_probabilities = torch.sigmoid(existence_logits)  # Convert to probabilities [0, 1]
-        
-        # Calculate dynamic vertex counts based on existence probabilities
-        # Use threshold of 0.5 to determine if vertex exists
-        vertex_exists = existence_probabilities > 0.5  # (batch_size, max_vertices)
-        actual_vertex_counts = vertex_exists.sum(dim=1)  # (batch_size,)
-        
+        vertex_coords = vertex_features[:, :, :3]                    # (B, max_vertices, 3)
+        existence_logits = vertex_features[:, :, 3]                  # (B, max_vertices)
+        existence_probabilities = torch.sigmoid(existence_logits)    # (B, max_vertices)
+
+        # Calculate dynamic vertex counts based on existence probabilities (threshold=0.5)
+        vertex_exists = existence_probabilities > 0.5                # (B, max_vertices)
+        actual_vertex_counts = vertex_exists.sum(dim=1)              # (B,)
+
         return {
-            'vertices': vertex_coords,                           # Predicted 3D coordinates (batch_size, max_vertices, 3)
-            'existence_probabilities': existence_probabilities,  # Vertex existence probabilities (batch_size, max_vertices)
-            'actual_vertex_counts': actual_vertex_counts         # Dynamic vertex counts based on probabilities
+            'vertices': vertex_coords,
+            'existence_probabilities': existence_probabilities,
+            'actual_vertex_counts': actual_vertex_counts
         }

--- a/train.py
+++ b/train.py
@@ -123,7 +123,7 @@ def train_overfit_model(batch_data, num_epochs=5000, learning_rate=0.001, wandb_
     # 2. Plateau reduction with conservative parameters
     scheduler_plateau = torch.optim.lr_scheduler.ReduceLROnPlateau(
         optimizer, mode='min', factor=0.8, patience=50, threshold=0.005, 
-        threshold_mode='rel', cooldown=20, min_lr=learning_rate * 1e-3, verbose=False  # Higher min LR
+        threshold_mode='rel', cooldown=20, min_lr=learning_rate * 1e-3  # Higher min LR
     )
     
     # 3. Dynamic loss weight adjustment for fine-tuning phase

--- a/wandb_run_id.txt
+++ b/wandb_run_id.txt
@@ -1,1 +1,1 @@
-crrxubl0
+19qerpqu


### PR DESCRIPTION
The VertexPredictor now accepts per-point features, pools and projects them, and fuses with global features for improved vertex prediction. PointCloudToWireframe and its call to VertexPredictor are updated accordingly. Also, a redundant argument is removed from the learning rate scheduler in train.py.